### PR TITLE
Implement Zoom-in on Cards

### DIFF
--- a/client/components/CarouselCard.jsx
+++ b/client/components/CarouselCard.jsx
@@ -3,24 +3,40 @@ import styled from 'styled-components';
 
 
 const Image = styled.img`
+
   border: 1px solid black;
-  margin: 2px;
-  :nth-of-type(n+2) {
-    width: 21%;
-    height: 21%;
-  }
-  :first-of-type {
-    float: left;
-    padding: 0px
-  }
+  background: no-repeat url(${({ imageUrl }) => imageUrl});
+  background-size: cover;
+  background-position: center;
+  min-width: 100%;
+  min-height: 100%;
+  :hover {
+  color: #424242; 
+  background-size:cover;
+
+  -webkit-transition: all .3s ease-out;
+  -moz-transition: all .3s ease-out;
+  -ms-transition: all .3s ease-out;
+  -o-transition: all .3s ease-out;
+  transition: all .3s ease-out;
+  opacity: 1;
+  transform: scale(1.3);
+  -ms-transform: scale(1.3); /* IE 9 */
+  -webkit-transform: scale(1.3); /* Safari and Chrome */
+  }  
 `;
-const Wrapper = styled.div`
-  display: grid;
+
+const Wrap = styled.span`
+  position: relative;
+  overflow: hidden;
+  border: 1px solid transparent;
+  
 `;
 const CarouselCard = ({ imageUrl, key }) => (
-  // <Wrapper className="picture-row">
-  <Image className="media-element" src={imageUrl} key={key} alt="pictures" />
-  // </Wrapper>
+  <Wrap>
+    <Image imageUrl={imageUrl} key={key} alt="pictures" />
+  </Wrap>
+
 );
 
 export default CarouselCard;

--- a/client/components/CarouselLanding.jsx
+++ b/client/components/CarouselLanding.jsx
@@ -3,7 +3,47 @@
 import React from 'react';
 import axios from 'axios';
 import url from 'url';
+// import { Grid } from '../css/CarouselLanding';
+import styled from 'styled-components';
 import CarouselCard from './CarouselCard';
+
+// const Wrapper = styled.div`
+
+//   img:first-of-type {
+//     max-width: 40%;
+//     max-height: 40%;
+//     overflow:hidden;
+//   }
+//   img:nth-of-type(n+2) {
+
+//     margin: 1px;
+
+//     max-height: 150px;
+//     max-width: 150px;
+//     overflow: hidden;
+//   }
+
+// `;
+const Wrapper = styled.div`
+  display: grid;
+  grid-template-columns: auto 350px 350px;
+  grid-auto-rows: 350px
+  gap: 0px;
+  column-gap: 0px;
+`;
+
+const OneLot = styled.div`
+  display: grid;
+  grid-column: 1/3;
+  gap: 0px;
+`;
+
+const FourLot = styled.div`
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  border:1px solid transparent;
+  overflow:hidden;
+`;
 
 class CarouselLanding extends React.Component {
   constructor() {
@@ -12,6 +52,7 @@ class CarouselLanding extends React.Component {
       imageUrls: [],
     };
   }
+
 
   componentDidMount() {
     const currentUrl = window.location.href;
@@ -33,11 +74,19 @@ class CarouselLanding extends React.Component {
     const { imageUrls } = this.state;
 
     return (
-      <div>
-        {imageUrls.map((imageUrl, key) => (
-          <CarouselCard key={key} imageUrl={imageUrl} />
-        ))}
-      </div>
+      <Wrapper>
+        <OneLot>
+          <CarouselCard imageUrl={imageUrls[0]} />
+        </OneLot>
+        <FourLot>
+          {
+            imageUrls.map((imageUrl, key) => (
+              <CarouselCard key={key} imageUrl={imageUrl} />
+            )).slice(1)
+          }
+        </FourLot>
+      </Wrapper>
+
     );
   }
 }

--- a/client/components/CarouselLanding.jsx
+++ b/client/components/CarouselLanding.jsx
@@ -24,21 +24,23 @@ import CarouselCard from './CarouselCard';
 //   }
 
 // `;
-const Wrapper = styled.div`
+const LandingPhotoGrid = styled.div`
   display: grid;
   grid-template-columns: auto 350px 350px;
   grid-auto-rows: 350px
   gap: 0px;
   column-gap: 0px;
+  margin-left: 10%;
+  margin-right: 10%;
 `;
 
-const OneLot = styled.div`
+const MainLandingPhotoStyled = styled.div`
   display: grid;
   grid-column: 1/3;
   gap: 0px;
 `;
 
-const FourLot = styled.div`
+const SideLandingPhotoGrid = styled.div`
   display: grid;
   grid-template-columns: 1fr 1fr;
   border:1px solid transparent;
@@ -74,18 +76,18 @@ class CarouselLanding extends React.Component {
     const { imageUrls } = this.state;
 
     return (
-      <Wrapper>
-        <OneLot>
+      <LandingPhotoGrid>
+        <MainLandingPhotoStyled>
           <CarouselCard imageUrl={imageUrls[0]} />
-        </OneLot>
-        <FourLot>
+        </MainLandingPhotoStyled>
+        <SideLandingPhotoGrid>
           {
             imageUrls.map((imageUrl, key) => (
               <CarouselCard key={key} imageUrl={imageUrl} />
             )).slice(1)
           }
-        </FourLot>
-      </Wrapper>
+        </SideLandingPhotoGrid>
+      </LandingPhotoGrid>
 
     );
   }

--- a/client/index.jsx
+++ b/client/index.jsx
@@ -2,10 +2,6 @@ import React from 'react';
 import { render } from 'react-dom';
 import CarouselCentral from './CarouselCentral';
 
-// constructor() {
-//   super();
-// }
-// render() {
 const ModuleRefresh = () => {
   render(<CarouselCentral />, document.getElementById('carouselroot'));
 };


### PR DESCRIPTION
I scrapped the previous implementation of Zoom cards for a css grid-based approach.
Also found a way to use transform, background-images and overflow hidden to mimic the airbnb zoom effect.